### PR TITLE
Fixes to allow modules (not including whois.cpp) to *BUILD* in ZNC-1.0. ...

### DIFF
--- a/broadcast.cpp
+++ b/broadcast.cpp
@@ -14,14 +14,16 @@
 
 
 
-#include "znc.h"
-#include "User.h"
+#include "znc/znc.h"
+#include "znc/User.h"
 
 using std::map;
 
-class CBroadcastMod : public CGlobalModule {
+class CBroadcastMod : public CModule {
 public:
-	GLOBALMODCONSTRUCTOR(CBroadcastMod) {}
+	MODCONSTRUCTOR(CBroadcastMod) 
+    {
+    }
    
 	virtual ~CBroadcastMod() {}
    
@@ -72,4 +74,4 @@ private:
 	CString bcprefix;
 };
 
-GLOBALMODULEDEFS(CBroadcastMod, "Broadcast with a prefix. Version 0.01");
+GLOBALMODULEDEFS(CBroadcastMod, "Broadcast with a prefix. Version 1.0");

--- a/dns.cpp
+++ b/dns.cpp
@@ -15,9 +15,9 @@
 
 
 
-#include "User.h"
-#include "IRCSock.h"
-#include "znc.h"
+#include "znc/User.h"
+#include "znc/IRCSock.h"
+#include "znc/znc.h"
 #include <stdio.h>
 #include <netdb.h>
 #include <sys/types.h>
@@ -26,9 +26,9 @@
 
 using std::map;
 
-class CDNSMod : public CGlobalModule {
+class CDNSMod : public CModule {
 public:
-	GLOBALMODCONSTRUCTOR(CDNSMod) {}
+	MODCONSTRUCTOR(CDNSMod) {}
    
 	virtual ~CDNSMod() {}
    
@@ -67,4 +67,4 @@ protected:
 private:
 };
 
-GLOBALMODULEDEFS(CDNSMod, "DNS Resolver. Version 0.01");
+GLOBALMODULEDEFS(CDNSMod, "DNS Resolver. Version 1.0");

--- a/killnotice.cpp
+++ b/killnotice.cpp
@@ -12,13 +12,13 @@
  * -Efreak
  */
 
-#include "znc.h"
-#include "User.h"
-#include "Modules.h"
+#include "znc/znc.h"
+#include "znc/User.h"
+#include "znc/Modules.h"
 
-class CKillNoticeMod : public CGlobalModule {
+class CKillNoticeMod : public CModule {
 public:
-        GLOBALMODCONSTRUCTOR(CKillNoticeMod) {}
+        MODCONSTRUCTOR(CKillNoticeMod) {}
 
         EModRet OnRaw(CString& sLine) {
                 CString sCmd = sLine.Token(0).AsUpper();
@@ -40,4 +40,4 @@ private:
         }
 
 };
-GLOBALMODULEDEFS(CKillNoticeMod, "Sends admins a notice when a user gets killed. Version 0.01")
+GLOBALMODULEDEFS(CKillNoticeMod, "Sends admins a notice when a user gets killed. Version 1.0")

--- a/quitaway.cpp
+++ b/quitaway.cpp
@@ -12,9 +12,9 @@
  * -Efreak
  */
 
-#include "Chan.h"
-#include "User.h"
-#include "Modules.h"
+#include "znc/Chan.h"
+#include "znc/User.h"
+#include "znc/Modules.h"
 
 class CQuitAway : public CModule {
 public:
@@ -43,7 +43,7 @@ public:
 	}
 };
 
-MODULEDEFS(CQuitAway, "Set away message on quit (from quit message). Version 0.01")
+MODULEDEFS(CQuitAway, "Set away message on quit (from quit message). Version 1.0")
 
 /*
 on modulecall user raw {


### PR DESCRIPTION
I wanted quitaway, but it didn't build, so I looked to see if I could fix it. While I was about it, I was able to fix most of the other modules, though not whois, which would require more refactoring, due to the shift away from one-network-per-user to many-networks-per-user.

...May not actually work at runtime, didn't test much.
- Corrected #include paths to include znc/
- Replaced CGlobalModule with CModule - in 1.0, global/local is determined at runtime
- whois.cpp would require additional refactoring to build correctly in 1.0
